### PR TITLE
[Feature] [Clone from PR#10645] Support deterministic inference with triton backend 

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1172,25 +1172,3 @@ def update_sliding_window_buffer_cuda_graph(
             )
         )
     return window_kv_indptr, window_kv_indices, window_kv_lens, window_kv_start_idx
-
-
-
-# def validate_deterministic_config(server_args):
-#     """
-#     Validate configuration for deterministic inference mode.
-#     Ensures all necessary parameters are set correctly for batch invariance.
-#     """
-#     if server_args.enable_deterministic_inference:
-#         if server_args.triton_attention_split_tile_size is None:
-#             logger.warning(
-#                 "Deterministic inference enabled but split_tile_size not set. "
-#                 "Using default value of 256. For better performance, consider "
-#                 "tuning this parameter based on your model and hardware."
-#             )
-        
-#         logger.info(
-#             f"Deterministic inference enabled with split_tile_size: "
-#             f"{server_args.triton_attention_split_tile_size}"
-#         )
-    
-#     return True

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -118,7 +118,7 @@ DISAGG_TRANSFER_BACKEND_CHOICES = ["mooncake", "nixl", "ascend", "fake"]
 
 GRAMMAR_BACKEND_CHOICES = ["xgrammar", "outlines", "llguidance", "none"]
 
-DETERMINISTIC_ATTENTION_BACKEND_CHOICES = ["flashinfer"]
+DETERMINISTIC_ATTENTION_BACKEND_CHOICES = ["flashinfer", "triton"]
 
 
 # Allow external code to add more choices


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Part of https://github.com/sgl-project/sglang/issues/10278
Clone from [PR#10645](https://github.com/sgl-project/sglang/pull/10645)
Reference: [Defeating Non-Determinism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/)

Thanks to the earlier work from @Fridge003, @Edenzzzz, @hebiao064, and @Qiaolin-Yu in the following PRs:

FlashInfer: https://github.com/flashinfer-ai/flashinfer/pull/1675
SGLang FlashInfer: https://github.com/sgl-project/sglang/pull/10645
SGLang DET POC: https://github.com/sgl-project/sglang/pull/10417
SGLang Support deterministic inference with FA3 backend: https://github.com/sgl-project/sglang/pull/10651

## Context
Fix `sglang/python/sglang/srt/layers/attention/triton_backend.py` to support triton-backend deterministic inference

## Modifications
1. `python/sglang/srt/layers/attention/triton_backend.py`
2.  `python/sglang/srt/server_args.py`


## Accuracy Tests
Launch SGLang server:
```
python -m sglang.launch_server \
    --model-path Qwen/Qwen3-8B \
    --attention-backend triton \
    --mem-fraction-static 0.7 \
    --host 0.0.0.0 --port 30000 \
    --enable-deterministic-inference
```

```
python -m sglang.test.test_deterministic --test-mode single --profile --n-trials 50 

# --disable-radix-cache
Total samples: 50, Unique samples: 1
```

```
python3 -m sglang.test.test_deterministic --test-mode prefix --profile --n-trials 50

# --disable-radix-cache 
Prompt 1: total samples: 557, Unique samples: 1
Prompt 2: total samples: 518, Unique samples: 1
Long prompt: total samples: 200, Unique samples: 1
```

```
python3 -m sglang.test.test_deterministic --test-mode mixed --profile --n-trials 50 

# --disable-radix-cache
Prompt 1: total samples: 582, Unique samples: 1
Prompt 2: total samples: 460, Unique samples: 1
Long prompt: total samples: 233, Unique samples: 1
```

## Benchmarking and Profiling

## Checklist
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
